### PR TITLE
Randomize local design order in swipe game

### DIFF
--- a/src/SwipeGame.jsx
+++ b/src/SwipeGame.jsx
@@ -38,7 +38,8 @@ export default function SwipeGame({ participantId }) {
         // Fallback to local JSON if Supabase is unavailable or empty.
         const res = await fetch('/designs/index.json', { cache: 'no-store' });
         const json = await res.json();
-        setDesigns(json);
+        // Ensure locally loaded designs are presented in random order
+        setDesigns(shuffle(json));
       } catch (err) {
         console.error(err);
         setError('Failed to load designs');


### PR DESCRIPTION
## Summary
- shuffle locally loaded designs so swipe sequence is randomized even when Supabase data is unavailable

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896fd2d23fc832884f8aa8a5de8b25b