### PR TITLE
Handle Supabase insert errors

### DIFF
--- a/src/SwipeGame.jsx
+++ b/src/SwipeGame.jsx
@@ -68,13 +68,22 @@ export default function SwipeGame({ participantId }) {
     // Optimistically advance to the next card
     setIndex((prev) => prev + 1);
     try {
-      await supabase.from('swipes').insert({
+      const { error } = await supabase.from('swipes').insert({
         participant_id: participantId,
         design_id: designId,
         choice,
       });
+
+      if (error) {
+        console.error(error);
+        // Roll back the optimistic index increment and show an error
+        setIndex((prev) => prev - 1);
+        setError('Failed to save swipe');
+      }
     } catch (err) {
       console.error(err);
+      setIndex((prev) => prev - 1);
+      setError('Failed to save swipe');
     }
   };
 


### PR DESCRIPTION
## Summary
- capture `error` from Supabase insert in `handleSwipe`
- roll back card index and show message when insert fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896fe96e7308328976d45f6f475f526