### PR TITLE
Document setup and deployment in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,47 @@
-# React + Vite
-
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
-
-Currently, two official plugins are available:
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
 # noemi-survey-app
-# noemi-survey-app
+
+A React + Vite survey application that presents label designs in a Tinder-like swipe game. Swipes are stored in Supabase for later analysis.
+
+## Prerequisites
+- Node.js 20+
+- npm
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Create a `.env` file in the project root with your Supabase credentials:
+   ```bash
+   VITE_SUPABASE_URL=<your-supabase-url>
+   VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+   ```
+   The app expects `designs` and `swipes` tables to exist in your Supabase project.
+3. Add label images under `public/designs` for the swipe game.
+
+## Available scripts
+
+- `npm run dev` – start a local development server.
+- `npm run lint` – run ESLint to check code quality.
+- `npm run build` – create a production build in `dist/`.
+- `npm run preview` – serve the production build locally.
+
+## Testing
+
+This project does not currently include automated tests. Use the linter to catch common issues:
+
+```bash
+npm run lint
+```
+
+## Deployment
+
+The repository includes `netlify.toml` for Netlify deployments.
+
+1. Connect the repository to Netlify or deploy with the Netlify CLI.
+2. Configure the environment variables `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` in the Netlify site settings.
+3. Netlify build command: `npm run build`.
+4. Publish directory: `dist`.
+
+After deployment, the survey will be available at the Netlify-provided URL.


### PR DESCRIPTION
## Summary
- replace template README with project-specific instructions
- document environment variables, scripts, and Netlify deployment steps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896fea71334832894f05426dd2449d3