### PR TITLE
Allow survey retake in dev mode

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,8 +3,14 @@ import Survey from './Survey.jsx';
 import SwipeGame from './SwipeGame.jsx';
 import config from '../docs/noemi-survey-config.json';
 
+/**
+ * Root component orchestrating survey and game flow.
+ * Use `?dev=true` in the URL to always show the survey.
+ */
 export default function App() {
-  const storedId = typeof window !== 'undefined' ? localStorage.getItem('participant_id') : null;
+  const urlParams = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : null;
+  const devMode = urlParams?.get('dev') === 'true';
+  const storedId = typeof window !== 'undefined' && !devMode ? localStorage.getItem('participant_id') : null;
   const [step, setStep] = useState(storedId ? 'game' : 'welcome');
   const [participantId, setParticipantId] = useState(storedId);
 


### PR DESCRIPTION
## Summary
- allow bypassing stored participant ID when `?dev=true` is present

## Testing
- `npm run lint`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68970fe384388328bec45aef8f58ca65