### PR TITLE
Improve swipe game UI with directional hints and animations

### DIFF
--- a/src/SwipeGame.css
+++ b/src/SwipeGame.css
@@ -1,0 +1,91 @@
+ .swipe-game {
+   display: flex;
+   flex-direction: column;
+   align-items: center;
+ }
+
+ .sg-title {
+   font-family: 'Georgia, serif';
+ }
+
+ .sg-subtitle {
+   font-style: italic;
+   margin-bottom: 1rem;
+ }
+
+ .swipe-container {
+   position: relative;
+   width: 320px;
+   height: 320px;
+ }
+
+ .card {
+   background-color: #fff;
+   width: 100%;
+   height: 100%;
+   border-radius: 12px;
+   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+   display: flex;
+   align-items: center;
+   justify-content: center;
+   overflow: hidden;
+ }
+
+ .card img {
+   width: 100%;
+   height: 100%;
+   object-fit: cover;
+ }
+
+ .swipe-label {
+   position: absolute;
+   color: rgba(0, 0, 0, 0.6);
+   font-size: 0.8rem;
+   font-family: 'Georgia, serif';
+   pointer-events: none;
+ }
+
+ .swipe-label.left {
+   left: -40px;
+   top: 50%;
+   transform: rotate(-90deg) translate(-50%, 0);
+   transform-origin: left top;
+ }
+
+ .swipe-label.right {
+   right: -40px;
+   top: 50%;
+   transform: rotate(90deg) translate(50%, 0);
+   transform-origin: right top;
+ }
+
+ .swipe-label.up {
+   top: -30px;
+   left: 50%;
+   transform: translate(-50%, -50%);
+ }
+
+ .swipe-label.down {
+   bottom: -30px;
+   left: 50%;
+   transform: translate(-50%, 50%);
+ }
+
+ .swipe-feedback {
+   position: absolute;
+   top: 50%;
+   left: 50%;
+   transform: translate(-50%, -50%);
+   font-size: 4rem;
+   opacity: 0.8;
+   animation: fadeShrink 0.5s forwards;
+   pointer-events: none;
+ }
+
+ @keyframes fadeShrink {
+   to {
+     transform: translate(-50%, -50%) scale(0.5);
+     opacity: 0;
+   }
+ }
+


### PR DESCRIPTION
## Summary
- Expand swipe game to four directions and resurface unsure cards later
- Add permanent directional labels and swipe feedback icons

## Testing
- `npm run lint`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689710a6c8608328a75d5bb6ded5e88a