### PR TITLE
Validate required follow-ups in opt-in questions

### DIFF
--- a/src/Survey.jsx
+++ b/src/Survey.jsx
@@ -62,6 +62,12 @@ export default function Survey({ onComplete }) {
     }
   };
 
+  /**
+   * Determine whether the current question has been answered.
+   * For gate opt-in questions, validate required follow-up fields.
+   *
+   * @returns {boolean}
+   */
   const isAnswered = () => {
     const val = answers[current.id];
     if (!current.required) return true;
@@ -71,8 +77,15 @@ export default function Survey({ onComplete }) {
         return Array.isArray(val) && val.length > 0;
       case 'short_text_one_word':
         return !!val && val.trim().length > 0;
-      case 'gate_opt_in':
-        return val && val.join;
+      case 'gate_opt_in': {
+        if (!val || !val.join) return false;
+        if (val.join === 'yes' && current.follow_ups_if_yes) {
+          return current.follow_ups_if_yes.every(
+            (fu) => !fu.required || (val[fu.id] && val[fu.id].trim().length > 0),
+          );
+        }
+        return true;
+      }
       default:
         return !!val;
     }


### PR DESCRIPTION
## Summary
- ensure gate opt-in questions validate required follow-up fields

## Testing
- `npm run lint`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689710d1bb148328ac4a7e39e5337086