### PR TITLE
Fix dev flag to show survey

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,13 +5,13 @@ import config from '../docs/noemi-survey-config.json';
 
 /**
  * Root component orchestrating survey and game flow.
- * Use `?dev=true` in the URL to always show the survey.
+ * Use `?dev=true` in the URL to start directly at the survey.
  */
 export default function App() {
   const urlParams = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : null;
   const devMode = urlParams?.get('dev') === 'true';
   const storedId = typeof window !== 'undefined' && !devMode ? localStorage.getItem('participant_id') : null;
-  const [step, setStep] = useState(storedId ? 'game' : 'welcome');
+  const [step, setStep] = useState(devMode ? 'survey' : storedId ? 'game' : 'welcome');
   const [participantId, setParticipantId] = useState(storedId);
 
   const handleComplete = (id) => {


### PR DESCRIPTION
## Summary
- Start app at survey step when `?dev=true` is present
- Document that the dev flag loads survey directly

## Testing
- `npm run lint`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689712c0b93c83288b61d96570ac6ce7