### PR TITLE
Polyfill crypto.hash for Node compatibility

### DIFF
--- a/e2e/crypto-hash.spec.js
+++ b/e2e/crypto-hash.spec.js
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import { ensureCryptoHash } from '../scripts/ensureCryptoHash.js';
+
+/**
+ * Verify that ensureCryptoHash provides a fallback hash function.
+ */
+test('ensureCryptoHash polyfills hash when missing', async () => {
+  const fake = {
+    createHash: (algorithm) => ({
+      data: '',
+      update(d) {
+        this.data += d;
+        return this;
+      },
+      digest(enc) {
+        return `${algorithm}:${this.data}:${enc}`;
+      },
+    }),
+  };
+  ensureCryptoHash(fake);
+  expect(typeof fake.hash).toBe('function');
+  expect(fake.hash('sha256', 'data', 'hex')).toBe('sha256:data:hex');
+});

--- a/e2e/full-flow.spec.js
+++ b/e2e/full-flow.spec.js
@@ -33,7 +33,9 @@ test('complete survey and swipe ritual', async ({ page }) => {
   await page.getByRole('button', { name: 'Next' }).click();
 
   // Q3
-  await page.getByText('Serene self-care').click();
+  await page
+    .getByLabel('I take them consistently as part of my routine')
+    .check();
   await page.getByRole('button', { name: 'Next' }).click();
 
   // Q4
@@ -46,7 +48,7 @@ test('complete survey and swipe ritual', async ({ page }) => {
   await page.getByRole('button', { name: 'Next' }).click();
 
   // Q6
-  await page.getByRole('textbox').fill('candles');
+  await page.getByLabel('Capsule or pill').check();
   await page.getByRole('button', { name: 'Next' }).click();
 
   // Q7
@@ -64,9 +66,19 @@ test('complete survey and swipe ritual', async ({ page }) => {
   await page.getByRole('button', { name: 'Next' }).click();
 
   // Q10
+  await page.getByLabel('Very open').check();
+  await page.getByRole('button', { name: 'Next' }).click();
+
+  // Q11
+  await page.getByLabel('Yes, definitely').check();
+  await page.getByRole('button', { name: 'Next' }).click();
+
+  // Q12
   await page.getByLabel('Yes').check();
   await page.getByLabel('Email (optional)').fill('test@example.com');
-  await page.getByLabel('Instagram handle (optional)').fill('testhandle');
+  await page
+    .getByLabel('Instagram handle (optional)')
+    .fill('testhandle');
   await page.getByRole('button', { name: 'Reveal my archetype' }).click();
 
   await page.waitForSelector('.card img');

--- a/scripts/ensureCryptoHash.js
+++ b/scripts/ensureCryptoHash.js
@@ -1,0 +1,16 @@
+import crypto from 'node:crypto';
+
+/**
+ * Ensure crypto.hash is available for Node versions lacking it.
+ * Adds a fallback using createHash when necessary.
+ * @param {typeof import('node:crypto')} [c]
+ * @returns {void}
+ */
+export function ensureCryptoHash(c = crypto) {
+  if (typeof c.hash !== 'function') {
+    c.hash = (algorithm, data, encoding) =>
+      c.createHash(algorithm).update(data).digest(encoding);
+  }
+}
+
+ensureCryptoHash();

--- a/src/Survey.jsx
+++ b/src/Survey.jsx
@@ -20,7 +20,6 @@ export default function Survey({ onComplete }) {
   // Fire survey start once on mount
   useEffect(() => {
     onSurveyStart();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleChange = (id, value) => {

--- a/src/SwipeGame.jsx
+++ b/src/SwipeGame.jsx
@@ -44,7 +44,7 @@ export default function SwipeGame({ participantId }) {
         console.error('Failed to load designs', err);
         setDeck([]);
       });
-  }, []);
+  }, [participantId]);
 
   /**
    * Handle swipe direction and record choice.

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -7,30 +7,25 @@
 
 export function onSurveyStart() {
   // Called when the user begins the survey
-  // eslint-disable-next-line no-console
   console.debug('Analytics: survey_start');
 }
 
 export function onQuestionAnswered(questionId, answer) {
   // Called each time a question is answered
-  // eslint-disable-next-line no-console
   console.debug('Analytics: question_answered', { questionId, answer });
 }
 
 export function onSurveyComplete(participantId) {
   // Called when the survey has been submitted and a participant ID generated
-  // eslint-disable-next-line no-console
   console.debug('Analytics: survey_complete', { participantId });
 }
 
 export function onGameStart(participantId) {
   // Called when the swipe ritual game starts
-  // eslint-disable-next-line no-console
   console.debug('Analytics: game_start', { participantId });
 }
 
 export function onSwipe(participantId, cardId, choice) {
   // Called whenever the user swipes on a card
-  // eslint-disable-next-line no-console
   console.debug('Analytics: swipe', { participantId, cardId, choice });
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,8 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import './scripts/ensureCryptoHash.js';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+});


### PR DESCRIPTION
## Summary
- ensure crypto.hash exists in older Node versions via a small polyfill
- clean up lint warnings in Survey, SwipeGame and analytics modules
- update and expand Playwright tests to match latest survey flow

## Testing
- `pnpm run lint`
- `pnpm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6899c2f106c483289b64aa3254d91481