### PR TITLE
Refactor SwipeGame effect and enable lint autofix

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint .",
+    "lint": "eslint . --fix",
     "preview": "vite preview",
     "test:e2e": "playwright test"
   },

--- a/src/SwipeGame.jsx
+++ b/src/SwipeGame.jsx
@@ -30,20 +30,23 @@ export default function SwipeGame({ participantId }) {
   const [feedback, setFeedback] = useState(null);
 
   useEffect(() => {
-    // Fire a game start event when the component mounts
+    // Fire a game start event whenever the participant ID changes
     onGameStart(participantId);
 
-    fetch('/designs/index.json')
-      .then((res) => res.json())
-      .then((data) => {
+    async function loadDesigns() {
+      try {
+        const res = await fetch('/designs/index.json');
+        const data = await res.json();
         const subset = data.slice(0, 20);
         setDeck(subset);
         setInitialDeck(subset);
-      })
-      .catch((err) => {
+      } catch (err) {
         console.error('Failed to load designs', err);
         setDeck([]);
-      });
+      }
+    }
+
+    loadDesigns();
   }, [participantId]);
 
   /**


### PR DESCRIPTION
## Summary
- refactor SwipeGame effect to handle participant changes and load designs with async/await
- run eslint with --fix by default

## Testing
- `pnpm run lint`
- `pnpm run test` *(fails: Missing script)*
- `pnpm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_689a7130326883289dcd2e54b528a6a0