### PR TITLE
Add keyboard controls for swipe game

### DIFF
--- a/e2e/survey_submit_and_unlock_game.spec.js
+++ b/e2e/survey_submit_and_unlock_game.spec.js
@@ -84,16 +84,9 @@ test('happy path: complete survey and unlock swipe game', async ({ page }) => {
   await page.waitForSelector('.card img');
   await expect(page.getByRole('heading', { name: 'Swipe Ritual' })).toBeVisible();
 
-  // Perform a right swipe on the first card
-  const card = page.locator('.card').first();
-  const box = await card.boundingBox();
-  if (box) {
-    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-    await page.mouse.down();
-    await page.mouse.move(box.x + box.width + 200, box.y + box.height / 2, { steps: 10 });
-    await page.mouse.up();
-    await page.waitForTimeout(500);
-  }
+  // Perform a right swipe on the first card via keyboard
+  await page.keyboard.press('ArrowRight');
+  await page.waitForTimeout(500);
 
   // Expect there are still cards left (the deck rotates or reduces)
   await expect(page.locator('.card')).toBeVisible();

--- a/src/SwipeGame.jsx
+++ b/src/SwipeGame.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { onGameStart, onSwipe as trackSwipe } from './analytics.js';
 import TinderCard from 'react-tinder-card';
 import config from '../docs/noemi-survey-config.json';
@@ -17,6 +17,13 @@ const ICON_MAP = {
   left: '👎',
   up: '❤️',
   down: '❓',
+};
+
+const KEY_MAP = {
+  ArrowRight: 'right',
+  ArrowLeft: 'left',
+  ArrowUp: 'up',
+  ArrowDown: 'down',
 };
 
 /**
@@ -54,7 +61,7 @@ export default function SwipeGame({ participantId }) {
    * @param {string} direction
    * @returns {Promise<void>}
    */
-  const handleSwipe = async (direction) => {
+  const handleSwipe = useCallback(async (direction) => {
     const choice = CHOICE_MAP[direction];
     if (!choice || !deck?.length) return;
 
@@ -91,7 +98,27 @@ export default function SwipeGame({ participantId }) {
     } catch (err) {
       console.error(err);
     }
-  };
+  }, [deck, participantId]);
+
+  /**
+   * Bind arrow key presses to swipe directions.
+   * @param {KeyboardEvent} e
+   */
+  const handleKeyDown = useCallback(
+    (e) => {
+      const direction = KEY_MAP[e.key];
+      if (direction) {
+        e.preventDefault();
+        handleSwipe(direction);
+      }
+    },
+    [handleSwipe],
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
 
   if (deck === null) {
     return <p>Loading designs…</p>;


### PR DESCRIPTION
## Summary
- Enable arrow key bindings in SwipeGame so desktop users can swipe using keyboard
- Test keyboard swipe via Playwright e2e

## Testing
- `pnpm run lint`
- `pnpm run test` *(fails: Missing script: test)*
- `pnpm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689a73e0df3c8328a4905e69a2b2ebab