### PR TITLE
Add swipe tutorial and undo feature

### DIFF
--- a/e2e/full-flow.spec.js
+++ b/e2e/full-flow.spec.js
@@ -85,11 +85,11 @@ test('complete survey and swipe ritual', async ({ page }) => {
   await expect(
     page.getByRole('heading', { name: 'Swipe Ritual' })
   ).toBeVisible();
+  await page.waitForSelector('.card.tutorial', { state: 'detached' });
 
   const imgSrc = await page.locator('.card img').first().getAttribute('src');
   expect(imgSrc).toContain('/designs/');
 
-  // Perform a swipe to the right on the first card.
   const card = page.locator('.card').first();
   const box = await card.boundingBox();
   if (box) {

--- a/e2e/survey_submit_and_unlock_game.spec.js
+++ b/e2e/survey_submit_and_unlock_game.spec.js
@@ -83,8 +83,7 @@ test('happy path: complete survey and unlock swipe game', async ({ page }) => {
   // After completion we should land on the Swipe Ritual game
   await page.waitForSelector('.card img');
   await expect(page.getByRole('heading', { name: 'Swipe Ritual' })).toBeVisible();
-
-  // Perform a right swipe on the first card
+  await page.waitForSelector('.card.tutorial', { state: 'detached' });
   const card = page.locator('.card').first();
   const box = await card.boundingBox();
   if (box) {
@@ -94,7 +93,5 @@ test('happy path: complete survey and unlock swipe game', async ({ page }) => {
     await page.mouse.up();
     await page.waitForTimeout(500);
   }
-
-  // Expect there are still cards left (the deck rotates or reduces)
   await expect(page.locator('.card')).toBeVisible();
 });

--- a/src/SwipeGame.css
+++ b/src/SwipeGame.css
@@ -5,6 +5,10 @@
   flex-direction: column;
   align-items: center;
   gap: 1rem;
+  height: 100vh;
+  max-height: 100vh;
+  justify-content: center;
+  overflow: hidden;
 }
 
 
@@ -21,8 +25,8 @@
 
 .swipe-container {
   position: relative;
-  width: 320px;
-  height: 320px;
+  width: min(80vw, 80vh, 320px);
+  height: min(80vw, 80vh, 320px);
 }
 
 .card {
@@ -47,10 +51,14 @@
 .swipe-label {
   position: absolute;
   color: rgba(90, 67, 51, 0.6);
-  font-size: 0.8rem;
+  font-size: 1.2rem;
   font-family: 'Playfair Display', serif;
   pointer-events: none;
   user-select: none;
+}
+
+.swipe-label.active {
+  color: #5a4333;
 }
 
 /* Side labels sit just outside the card and are rotated */
@@ -91,6 +99,27 @@
   animation: fadeShrink 0.5s forwards;
   pointer-events: none;
   will-change: transform, opacity;
+}
+
+.card.tutorial {
+  transition: transform 0.3s ease;
+  pointer-events: none;
+}
+
+.card.tutorial.hint-right {
+  transform: translateX(40px) rotate(5deg);
+}
+
+.card.tutorial.hint-left {
+  transform: translateX(-40px) rotate(-5deg);
+}
+
+.card.tutorial.hint-up {
+  transform: translateY(-40px) rotate(-5deg);
+}
+
+.card.tutorial.hint-down {
+  transform: translateY(40px) rotate(5deg);
 }
 
 @keyframes fadeShrink {

--- a/src/SwipeGame.jsx
+++ b/src/SwipeGame.jsx
@@ -28,6 +28,9 @@ export default function SwipeGame({ participantId }) {
   const [deck, setDeck] = useState(null);
   const [initialDeck, setInitialDeck] = useState([]);
   const [feedback, setFeedback] = useState(null);
+  const [history, setHistory] = useState([]);
+  const [showTutorial, setShowTutorial] = useState(true);
+  const [tutorialDir, setTutorialDir] = useState(null);
 
   useEffect(() => {
     // Fire a game start event whenever the participant ID changes
@@ -40,6 +43,7 @@ export default function SwipeGame({ participantId }) {
         const subset = data.slice(0, 20);
         setDeck(subset);
         setInitialDeck(subset);
+        setShowTutorial(true);
       } catch (err) {
         console.error('Failed to load designs', err);
         setDeck([]);
@@ -48,6 +52,74 @@ export default function SwipeGame({ participantId }) {
 
     loadDesigns();
   }, [participantId]);
+
+  useEffect(() => {
+    if (!deck || !showTutorial) return;
+    async function runTutorial() {
+      const sequence = ['right', 'left', 'up', 'down'];
+      for (const dir of sequence) {
+        setTutorialDir(dir);
+        await new Promise((r) => setTimeout(r, 400));
+        setTutorialDir(null);
+        await new Promise((r) => setTimeout(r, 200));
+      }
+      setShowTutorial(false);
+    }
+    runTutorial();
+  }, [deck, showTutorial]);
+
+  /**
+   * Persist a swipe choice.
+   * @param {string} cardId
+   * @param {string} choice
+   * @returns {Promise<void>}
+   */
+  const saveSwipe = async (cardId, choice) => {
+    try {
+      if (supabase) {
+        await supabase.from('swipes').insert({
+          participant_id: participantId,
+          card_id: cardId,
+          choice,
+        });
+      } else {
+        await fetch('https://lzzgroksxrqkwyvykmka.supabase.co/rest/v1/swipes', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ participant_id: participantId, card_id: cardId, choice }),
+        });
+      }
+      trackSwipe(participantId, cardId, choice);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  /**
+   * Remove a swipe record to support undo.
+   * @param {string} cardId
+   * @returns {Promise<void>}
+   */
+  const removeSwipe = async (cardId) => {
+    try {
+      if (supabase) {
+        await supabase
+          .from('swipes')
+          .delete()
+          .match({ participant_id: participantId, card_id: cardId });
+      } else {
+        await fetch(
+          `https://lzzgroksxrqkwyvykmka.supabase.co/rest/v1/swipes?participant_id=eq.${participantId}&card_id=eq.${cardId}`,
+          {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   /**
    * Handle swipe direction and record choice.
@@ -59,37 +131,33 @@ export default function SwipeGame({ participantId }) {
     if (!choice || !deck?.length) return;
 
     const current = deck[0];
+    setHistory((prev) => [...prev, { deck: [...deck], card: current }]);
 
-    // Show quick emoji feedback
     setFeedback({ icon: ICON_MAP[direction], key: Date.now() });
     setTimeout(() => setFeedback(null), 1000);
 
-    // Rotate current card to back if "down" (unsure), otherwise remove it
     setDeck((prev) => {
       const [first, ...rest] = prev;
       return direction === 'down' ? [...rest, first] : rest;
     });
 
-    // Persist swipe
-    try {
-      if (supabase) {
-        await supabase.from('swipes').insert({
-          participant_id: participantId,
-          card_id: current.id,
-          choice,
-        });
-      } else {
-        await fetch('https://lzzgroksxrqkwyvykmka.supabase.co/rest/v1/swipes', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ participant_id: participantId, card_id: current.id, choice }),
-        });
-      }
+    await saveSwipe(current.id, choice);
+  };
 
-      // Emit analytics event for the swipe
-      trackSwipe(participantId, current.id, choice);
-    } catch (err) {
-      console.error(err);
+  /**
+   * Restore the previous deck state and remove persisted swipe.
+   * @returns {Promise<void>}
+   */
+  const handleUndo = async () => {
+    let lastEntry;
+    setHistory((prev) => {
+      if (!prev.length) return prev;
+      lastEntry = prev[prev.length - 1];
+      setDeck(lastEntry.deck);
+      return prev.slice(0, -1);
+    });
+    if (lastEntry) {
+      await removeSwipe(lastEntry.card.id);
     }
   };
 
@@ -103,7 +171,11 @@ export default function SwipeGame({ participantId }) {
         <p className="sg-subtitle">Thanks for swiping!</p>
         <button
           type="button"
-          onClick={() => setDeck(initialDeck)}
+          onClick={() => {
+            setDeck(initialDeck);
+            setHistory([]);
+            setShowTutorial(true);
+          }}
           className="lux-button-primary"
         >
           Play Again
@@ -117,25 +189,50 @@ export default function SwipeGame({ participantId }) {
   return (
     <div className="swipe-game">
       <h2 className="sg-title">{config.swipe_ritual.title}</h2>
-      <p className="sg-subtitle">{config.swipe_ritual.subtitle}</p>
 
       <div className="swipe-container">
-        <TinderCard key={current.id} onSwipe={handleSwipe}>
-          <div className="card">
-            <img src={
-              current.image_url} 
-              alt={`Design ${current.id}`} 
-              loading="lazy" 
+        {showTutorial ? (
+          <div
+            className={`card tutorial${
+              tutorialDir ? ` hint-${tutorialDir}` : ''
+            }`}
+          >
+            <img
+              src={current.image_url}
+              alt={`Design ${current.id}`}
+              loading="lazy"
               onError={(e) => {
                 e.currentTarget.src = '/vite.svg';
-              }}/>
+              }}
+            />
           </div>
-        </TinderCard>
+        ) : (
+          <TinderCard key={current.id} onSwipe={handleSwipe}>
+            <div className="card">
+              <img
+                src={current.image_url}
+                alt={`Design ${current.id}`}
+                loading="lazy"
+                onError={(e) => {
+                  e.currentTarget.src = '/vite.svg';
+                }}
+              />
+            </div>
+          </TinderCard>
+        )}
 
-        <span className="swipe-label left">Dislike</span>
-        <span className="swipe-label right">Like</span>
-        <span className="swipe-label up">Love</span>
-        <span className="swipe-label down">Unsure</span>
+        <span className={`swipe-label left${tutorialDir === 'left' ? ' active' : ''}`}>
+          Dislike
+        </span>
+        <span className={`swipe-label right${tutorialDir === 'right' ? ' active' : ''}`}>
+          Like
+        </span>
+        <span className={`swipe-label up${tutorialDir === 'up' ? ' active' : ''}`}>
+          Love
+        </span>
+        <span className={`swipe-label down${tutorialDir === 'down' ? ' active' : ''}`}>
+          Unsure
+        </span>
 
         {feedback && (
           <div key={feedback.key} className="swipe-feedback" aria-live="polite">
@@ -143,6 +240,16 @@ export default function SwipeGame({ participantId }) {
           </div>
         )}
       </div>
+
+      {history.length > 0 && (
+        <button
+          type="button"
+          onClick={handleUndo}
+          className="lux-button-secondary"
+        >
+          Undo
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- teach players with an automatic swipe tutorial and larger direction labels
- let players undo the last swipe and replay the game without instructions text
- keep the swipe game within the viewport height for better mobile layout

## Testing
- `pnpm run lint`
- `pnpm run test` (fails: Missing script: test)
- `pnpm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689a71bfd7348328b2c5ba7b7b6f4f4b