### PR TITLE
Center logo and update branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/png" href="/noemi_favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>NOEMI Research Survey</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,9 @@ export default function App() {
 
   return (
     <div className="lux-container">
+      <header className="app-header">
+        <img src="/logo.png" alt="NOEMI logo" className="app-logo" />
+      </header>
       {step === 'welcome' && (
         <div style={{ textAlign: 'center', display: 'flex', flexDirection: 'column', gap: '1rem' }}>
           <h1>{config.survey.meta.title}</h1>

--- a/src/SwipeGame.jsx
+++ b/src/SwipeGame.jsx
@@ -36,7 +36,6 @@ export default function SwipeGame({ participantId }) {
   const [initialDeck, setInitialDeck] = useState([]);
 
   const [feedbacks, setFeedbacks] = useState([]);
-  const [feedback, setFeedback] = useState(null);
   const [history, setHistory] = useState([]);
   const [showTutorial, setShowTutorial] = useState(true);
   const [tutorialDir, setTutorialDir] = useState(null);
@@ -83,7 +82,7 @@ export default function SwipeGame({ participantId }) {
    * @param {string} choice
    * @returns {Promise<void>}
    */
-  const saveSwipe = async (cardId, choice) => {
+  const saveSwipe = useCallback(async (cardId, choice) => {
     try {
       if (supabase) {
         await supabase.from('swipes').insert({
@@ -102,14 +101,14 @@ export default function SwipeGame({ participantId }) {
     } catch (err) {
       console.error(err);
     }
-  };
+  }, [participantId]);
 
   /**
    * Remove a swipe record to support undo.
    * @param {string} cardId
    * @returns {Promise<void>}
    */
-  const removeSwipe = async (cardId) => {
+  const removeSwipe = useCallback(async (cardId) => {
     try {
       if (supabase) {
         await supabase
@@ -128,7 +127,7 @@ export default function SwipeGame({ participantId }) {
     } catch (err) {
       console.error(err);
     }
-  };
+  }, [participantId]);
 
   /**
    * Handle swipe direction and record choice.
@@ -149,9 +148,6 @@ export default function SwipeGame({ participantId }) {
     setTimeout(() => {
       setFeedbacks((prev) => prev.filter((f) => f.id !== id));
     }, 1500);
-    
-    setFeedback({ icon: ICON_MAP[direction], key: Date.now() });
-    setTimeout(() => setFeedback(null), 1000);
 
     setDeck((prev) => {
       const [first, ...rest] = prev;
@@ -159,13 +155,13 @@ export default function SwipeGame({ participantId }) {
     });
 
     await saveSwipe(current.id, choice);
-  };
+  }, [deck, saveSwipe]);
 
   /**
    * Restore the previous deck state and remove persisted swipe.
    * @returns {Promise<void>}
    */
-  const handleUndo = async () => {
+  const handleUndo = useCallback(async () => {
     let lastEntry;
     setHistory((prev) => {
       if (!prev.length) return prev;
@@ -176,7 +172,7 @@ export default function SwipeGame({ participantId }) {
     if (lastEntry) {
       await removeSwipe(lastEntry.card.id);
     }
-  }, [deck, participantId]);
+  }, [removeSwipe]);
 
   /**
    * Bind arrow key presses to swipe directions.

--- a/src/index.css
+++ b/src/index.css
@@ -120,6 +120,16 @@ button:focus-visible {
   outline: 2px solid #274a82;
 }
 
+.app-header {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.app-logo {
+  max-width: 150px;
+  height: auto;
+}
+
 @media (prefers-reduced-motion: reduce) {
   body {
     transition: none !important;


### PR DESCRIPTION
## Summary
- center NOEMI logo across the app with simple header styling
- replace default Vite assets with NOEMI favicon and page title
- refactor swipe game callbacks to satisfy linting

## Testing
- `pnpm run lint`
- `pnpm run test` *(fails: Missing script: test)*
- `pnpm run test:e2e` *(fails: 4 failed tests)*


------
https://chatgpt.com/codex/tasks/task_e_689a80fab0bc8328882425c57ac91441