### PR TITLE
Render designs via canvas and add Instagram sharing

### DIFF
--- a/docs/noemi-survey-config.json
+++ b/docs/noemi-survey-config.json
@@ -2,6 +2,7 @@
   "version": "1.0.1",
   "brand": {
     "name": "NOEMI",
+    "instagram": "@noemi",
     "voice": {
       "tone": ["luxury","elegant","inclusive","mystical"],
       "keywords": ["self-care","wellness","functional beauty","ritual","alchemy"]

--- a/e2e/instagram-share.spec.js
+++ b/e2e/instagram-share.spec.js
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('share to instagram button appears in game', async ({ page }) => {
+  await page.goto('/?play=true');
+  const btn = page.getByLabel('Share to Instagram');
+  await expect(btn).toBeVisible({ timeout: 15000 });
+});

--- a/src/DesignCanvas.jsx
+++ b/src/DesignCanvas.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Canvas-based image renderer to prevent easy saving.
+ * @param {{ src: string, alt: string }} props
+ * @returns {JSX.Element}
+ */
+export default function DesignCanvas({ src, alt }) {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => {
+      canvas.width = img.width;
+      canvas.height = img.height;
+      ctx.drawImage(img, 0, 0);
+    };
+    img.onerror = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+    };
+    img.src = src;
+  }, [src]);
+
+  useEffect(() => {
+    const prevent = async (e) => {
+      if (e.key === 'PrintScreen') {
+        e.preventDefault();
+        try {
+          await navigator.clipboard.writeText('');
+        } catch {
+          /* noop */
+        }
+      }
+    };
+    window.addEventListener('keydown', prevent);
+    return () => window.removeEventListener('keydown', prevent);
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-label={alt}
+      className="design-canvas"
+      onContextMenu={(e) => e.preventDefault()}
+    />
+  );
+}

--- a/src/DesignCanvas.test.jsx
+++ b/src/DesignCanvas.test.jsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { beforeAll, expect, test, vi } from 'vitest';
+import DesignCanvas from './DesignCanvas.jsx';
+
+beforeAll(() => {
+  HTMLCanvasElement.prototype.getContext = () => ({
+    drawImage: () => {},
+    clearRect: () => {},
+  });
+});
+
+test('renders image into canvas', () => {
+  render(<DesignCanvas src="/logo.png" alt="test" />);
+  const canvas = screen.getByLabelText('test');
+  expect(canvas.tagName).toBe('CANVAS');
+});
+
+test('clears clipboard on PrintScreen', async () => {
+  const writeText = vi.fn();
+  Object.assign(navigator, { clipboard: { writeText } });
+  render(<DesignCanvas src="/logo.png" alt="test" />);
+  window.dispatchEvent(new KeyboardEvent('keydown', { key: 'PrintScreen' }));
+  await Promise.resolve();
+  expect(writeText).toHaveBeenCalledWith('');
+});

--- a/src/SwipeGame.css
+++ b/src/SwipeGame.css
@@ -42,10 +42,11 @@
   overflow: hidden;
 }
 
-.card img {
+.card canvas {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  user-select: none;
 }
 
 .swipe-label {
@@ -99,6 +100,19 @@
   animation: fadeShrink 1s forwards;
   pointer-events: none;
   will-change: transform, opacity;
+}
+
+.instagram-share-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: rgba(255, 255, 255, 0.7);
+  border: none;
+  border-radius: 50%;
+  width: 2rem;
+  height: 2rem;
+  font-size: 0.8rem;
+  cursor: pointer;
 }
 
 .card.tutorial {

--- a/src/SwipeGame.jsx
+++ b/src/SwipeGame.jsx
@@ -3,6 +3,7 @@ import { onGameStart, onSwipe as trackSwipe } from './analytics.js';
 import TinderCard from 'react-tinder-card';
 import config from '../docs/noemi-survey-config.json';
 import { supabase } from './supabaseClient.js';
+import DesignCanvas from './DesignCanvas.jsx';
 import './SwipeGame.css';
 
 const CHOICE_MAP = {
@@ -39,6 +40,8 @@ export default function SwipeGame({ participantId }) {
   const [history, setHistory] = useState([]);
   const [showTutorial, setShowTutorial] = useState(true);
   const [tutorialDir, setTutorialDir] = useState(null);
+  const instagramHandle = config.brand?.instagram || '@noemi';
+  const current = deck?.[0];
 
   useEffect(() => {
     // Fire a game start event whenever the participant ID changes
@@ -138,8 +141,8 @@ export default function SwipeGame({ participantId }) {
     const choice = CHOICE_MAP[direction];
     if (!choice || !deck?.length) return;
 
-    const current = deck[0];
-    setHistory((prev) => [...prev, { deck: [...deck], card: current }]);
+    const card = deck[0];
+    setHistory((prev) => [...prev, { deck: [...deck], card }]);
 
     // REVISIT:
     // Show quick emoji feedback
@@ -154,7 +157,7 @@ export default function SwipeGame({ participantId }) {
       return direction === 'down' ? [...rest, first] : rest;
     });
 
-    await saveSwipe(current.id, choice);
+    await saveSwipe(card.id, choice);
   }, [deck, saveSwipe]);
 
   /**
@@ -194,6 +197,67 @@ export default function SwipeGame({ participantId }) {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [handleKeyDown]);
 
+  const handleShare = useCallback(async () => {
+    if (!current) return;
+    try {
+      const story = document.createElement('canvas');
+      story.width = 1080;
+      story.height = 1920;
+      const ctx = story.getContext('2d');
+      const gradient = ctx.createLinearGradient(0, 0, story.width, story.height);
+      gradient.addColorStop(0, '#e0d7ff');
+      gradient.addColorStop(1, '#ffe3e3');
+      ctx.fillStyle = gradient;
+      ctx.fillRect(0, 0, story.width, story.height);
+
+      const img = new Image();
+      img.crossOrigin = 'anonymous';
+      await new Promise((resolve, reject) => {
+        img.onload = resolve;
+        img.onerror = reject;
+        img.src = current.image_url;
+      });
+      const maxSize = 900;
+      const scale = Math.min(maxSize / img.width, maxSize / img.height);
+      const w = img.width * scale;
+      const h = img.height * scale;
+      const x = (story.width - w) / 2;
+      const y = 300;
+      ctx.drawImage(img, x, y, w, h);
+
+      const logo = new Image();
+      logo.crossOrigin = 'anonymous';
+      await new Promise((resolve) => {
+        logo.onload = resolve;
+        logo.onerror = resolve;
+        logo.src = '/logo.png';
+      });
+      const lw = 240;
+      const lh = (logo.height / logo.width) * lw || 80;
+      ctx.drawImage(logo, story.width - lw - 40, story.height - lh - 40, lw, lh);
+
+      ctx.fillStyle = '#5a4333';
+      ctx.font = '48px serif';
+      ctx.textAlign = 'center';
+      ctx.fillText('I loved this design…', story.width / 2, 120);
+      ctx.fillText('Cast your vote now', story.width / 2, 180);
+
+      ctx.font = '36px sans-serif';
+      ctx.fillText(instagramHandle, story.width / 2, story.height - 120);
+      const surveyUrl = window.location.origin;
+      ctx.font = '28px sans-serif';
+      ctx.fillText(surveyUrl, story.width / 2, story.height - 60);
+
+      const blob = await new Promise((resolve) => story.toBlob(resolve, 'image/png'));
+      if (navigator.share && blob) {
+        const file = new File([blob], 'story.png', { type: 'image/png' });
+        await navigator.share({ files: [file], title: 'NOEMI design', text: 'Check this out' });
+      }
+    } catch (err) {
+      console.error('Share failed', err);
+    }
+  }, [current, instagramHandle]);
+
   if (deck === null) {
     return <p>Loading designs…</p>;
   }
@@ -217,8 +281,6 @@ export default function SwipeGame({ participantId }) {
     );
   }
 
-  const current = deck[0];
-
   return (
     <div className="swipe-game">
       <h2 className="sg-title">{config.swipe_ritual.title}</h2>
@@ -230,29 +292,24 @@ export default function SwipeGame({ participantId }) {
               tutorialDir ? ` hint-${tutorialDir}` : ''
             }`}
           >
-            <img
-              src={current.image_url}
-              alt={`Design ${current.id}`}
-              loading="lazy"
-              onError={(e) => {
-                e.currentTarget.src = '/vite.svg';
-              }}
-            />
+            <DesignCanvas src={current.image_url} alt={`Design ${current.id}`} />
           </div>
         ) : (
           <TinderCard key={current.id} onSwipe={handleSwipe}>
             <div className="card">
-              <img
-                src={current.image_url}
-                alt={`Design ${current.id}`}
-                loading="lazy"
-                onError={(e) => {
-                  e.currentTarget.src = '/vite.svg';
-                }}
-              />
+              <DesignCanvas src={current.image_url} alt={`Design ${current.id}`} />
             </div>
           </TinderCard>
         )}
+
+        <button
+          type="button"
+          aria-label="Share to Instagram"
+          className="instagram-share-btn"
+          onClick={handleShare}
+        >
+          IG
+        </button>
 
         <span className={`swipe-label left${tutorialDir === 'left' ? ' active' : ''}`}>
           Dislike


### PR DESCRIPTION
## Summary
- render game design images on a canvas and block context menu / PrintScreen
- add Instagram handle to config and share-to-Instagram button that composes a story image
- style canvas and share button within swipe game
- clear clipboard on PrintScreen key to discourage screenshots

## Testing
- `pnpm run lint`
- `pnpm run test`
- `pnpm run test:e2e` *(fails: waiting for survey choices; 3 failed, 1 interrupted)*
- `pnpm run test:e2e -- e2e/instagram-share.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_689b0a57df408328808eb7259ba12f73