### PR TITLE
Ensure Playwright browsers install during setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint . --fix",
     "preview": "vite preview",
     "test": "vitest run --environment jsdom src",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "postinstall": "playwright install --with-deps"
   },
   "dependencies": {
     "@react-spring/web": "^9.7.5",


### PR DESCRIPTION
## Summary
- add `postinstall` script to install Playwright browsers so e2e tests run after dependencies are installed

## Testing
- `pnpm run lint`
- `pnpm run test`
- `pnpm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b1b95981c8328ad1b9020af8a2c4f